### PR TITLE
Use Clang 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer /nodefaultlib:msvcrt libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe /NODEFAULTLIB
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Download LLVM
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-ubuntu
+        run: clang-20 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-ubuntu
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}
@@ -53,14 +58,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download LLVM
         run: |
-          apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-18 main" \
-            | tee /etc/apt/sources.list.d/llvm.list
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          apt-get update && apt-get install -y clang-18 libfuzzer-18-dev llvm-18 llvm-18-dev
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
       - name: Build
-        run: clang-18 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
+        run: clang-20 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
       - uses: actions/upload-artifact@v4
         with:
           name: libfuzzer-dotnet-debian

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,18 @@ jobs:
           path: libfuzzer-dotnet-windows.exe
 
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
       - name: Download LLVM
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 20
+          apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
+            | tee /etc/apt/sources.list.d/llvm.list
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
+          apt-get update && apt-get install -y clang-20 libfuzzer-20-dev llvm-20 llvm-20-dev
       - name: Build
         run: clang-20 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-ubuntu
       - uses: actions/setup-dotnet@v4
@@ -58,9 +61,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download LLVM
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 20
+          apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-20 main" \
+            | tee /etc/apt/sources.list.d/llvm.list
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
+          apt-get update && apt-get install -y clang-20 libfuzzer-20-dev llvm-20 llvm-20-dev
       - name: Build
         run: clang-20 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-debian
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer -nodefaultlib:msvcrt libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror,-defaultlib:libcmt,-defaultlib:oldnames -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer -defaultlib:libcmt -defaultlib:oldnames libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer -Wl,-defaultlib:libcmt,-defaultlib:oldnames libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe -Wl,-defaultlib:libcmt,-defaultlib:oldnames
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download LLVM
         run: |
-          apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
+          #apt-get update && apt-get install -y lsb-release wget software-properties-common gnupg
           echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-            | tee /etc/apt/sources.list.d/llvm.list
+            | sudo tee /etc/apt/sources.list.d/llvm.list
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
-          apt-get update && apt-get install -y clang-20 libfuzzer-20-dev llvm-20 llvm-20-dev
+            | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
+          sudo apt-get update && sudo apt-get install -y clang-20 libfuzzer-20-dev llvm-20 llvm-20-dev
       - name: Build
         run: clang-20 -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet-ubuntu
       - uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer -nodefaultlib:msvcrt libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer /nodefaultlib:msvcrt libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe /NODEFAULTLIB
+        run: clang -Werror,-defaultlib:libcmt,-defaultlib:oldnames -O2 -fsanitize=fuzzer libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: clang -Werror -O2 -fsanitize=fuzzer -defaultlib:libcmt -defaultlib:oldnames libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
+        run: clang -Werror -O2 -fsanitize=fuzzer -Wl,-defaultlib:libcmt,-defaultlib:oldnames libfuzzer-dotnet-windows.cc -o libfuzzer-dotnet-windows.exe
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.dotnet-version }}


### PR DESCRIPTION
```
$ git log --oneline llvmorg-18.1.3..llvmorg-19.1.7 compiler-rt/lib/fuzzer/
d174e2a55389 [compiler-rt] [fuzzer] Skip trying to set the thread name on MinGW (#115167)
bfa99ebbc309 Fix libFuzzer not building with pthreads on Windows (#109525)
83251a22f623 [libFuzzer] Fix incorrect coverage number in fork mode (#82335)
b4b17d97637b Revert "[compiler-rt] Silence function cast warning when building with Clang ToT targetting Windows"
10e1b935e5d9 [compiler-rt] Silence function cast warning when building with Clang ToT targetting Windows
a35ac42fac88 [compiler-rt] Revise IDE folder structure (#89753)
d9ce33a0eea7 [libfuzzer] Prevent MSan false positive when printing log with -jobs (#91679)
791161516f48 [compiler-rt] Update libFuzzer build script to use C++17. (#89604)
55b90b5140a2 [compiler-rt] Remove llvm_gtest dependency from unit tests
e371ada409b2 [compiler-rt] reimplements GetMemoryProfile for netbsd. (#84841)
e932fe880b69 [compiler-rt][Fuzzer] fix windows typo (#84407)
8bf8d36f8e82 [compiler-rt][fuzzer] Reland "SetThreadName windows implementation" (#83562)
d1538c15f9c6 Revert fuzzer windows changes (#83551)
062d78ef58ac [compiler-rt][fuzzer] windows build unbreak proposal. (#83538)
2cdf611c0239 [compiler-rt][Fuzzer] SetThreadName windows implementation new try. (#76761)
7f3980a7b2c9 [Fuzzer] Use user signal to coordinate handler shutdown (#82067)
```

```
$ git log --oneline llvmorg-19.1.7..llvmorg-20.1.8 compiler-rt/lib/fuzzer/
091741a880c2 [libfuzzer] Clarify -max_len behavior on bigger files (#123095)
f9125ddc1faa Revert "[libfuzzer] use timer_create() instead of setitimer() for linux" (#115811)
3b29a8a00809 [libfuzzer] use timer_create() instead of setitimer() for linux (#110274)
5082acce4fd3 [compiler-rt] Add custom libc++ workaround for CMake < 3.26
87f4bc0acad6 [compiler-rt] [fuzzer] Skip trying to set the thread name on MinGW (#115167)
e7bad34475e2 [compiler-rt] Use installed libc++(abi) for tests instead of build tree
a6fdfefbd04d [compiler-rt] Include stdlib.h for exit() (#115025)
d54953ef472b [fuzzer] fix clang-cl build fuzzer lit test failure (#112339)
b4130bee6bfd Fix libFuzzer not building with pthreads on Windows (#109525)
b32dc677325c Revert "[compiler-rt][fuzzer] SetThreadName build fix for Mingwin attempt (#106902)"
7c4cffd9d8be [compiler-rt][fuzzer] SetThreadName build fix for Mingwin attempt (#106902)
f47966b1de45 [compiler-rt] Reland "SetThreadName implementation for Fuchsia" (#105179)
ddaa8284f5b4 Revert "[compiler-rt][fuzzer] implements SetThreadName for fuchsia." (#105162)
31cc4ccdea92 [compiler-rt][fuzzer] implements SetThreadName for fuchsia. (#99953)
bde4ffe75214 Don't pass null pointers to memcmp and memcpy in libFuzzer (#96775)
7202fe582931 [compiler-rt] Silence warnings
```

```
$ git log --oneline llvmorg-20.1.8..llvmorg-21.1.4 compiler-rt/lib/fuzzer/
f7cdff7bddcb [compiler-rt] Include missing headers for libFuzzer (#146828)
7b6963ea672f [compiler-rt] [Fuzzer] Fix tests linking buildbot failure (#144495)
6f4add34801e [compiler-rt] [Fuzzer] Fix ARMv7 test link failure by linking unwinder (#144495)
cd573e0a547d [compiler-rt] Remove unused local variables (NFC) (#144010)
```

```
$ git log --oneline llvmorg-21.1.8..llvmorg-22.1.0 compiler-rt/lib/fuzzer/
9d18e92ee78c [compiler-rt] Add CMake option to enable execute-only code generation on AArch64 (#140555)
be6c5d066379 [NFC] [compiler-rt] fix typos (#160803)
b928695c2fb8 [compiler-rt] fix typos (#160799)
3f52e97df77a Fix libFuzzer array alignment with empty modules (#159661)
46fd8d0db2f7 Reapply "[NFC] Fix CodeQL violations in compiler-rt. (#157793)" (#157913) (#159097)
8062b166762b Revert "[NFC] Fix CodeQL violations in compiler-rt. (#157793)" (#157913)
b44e6e01f7f7 [NFC] Fix CodeQL violations in compiler-rt. (#157793)
316004764fe3 [fuzzer][Fuchsia] Forward fix for undefined StartRssThread (#155514)
7153392a1089 Reapply "[fuzzer][Fuchsia] Prevent deadlock from suspending threads" … (#155271)
781a4db6b50b Revert "[fuzzer][Fuchsia] Prevent deadlock from suspending threads" (#155042)
b9987503d2ed [fuzzer][Fuchsia] Prevent deadlock from suspending threads (#154854)
03372c7782e6 Revert "[libFuzzer] always install signal handler with SA_ONSTACK" (#153114)
aee4f2baccdb [libFuzzer] always install signal handler with SA_ONSTACK (#147422)
33cc58f46f0c [compiler-rt][libFuzzer] Add support for capturing SIGTRAP exits. (#149120)
```